### PR TITLE
feat(backend): add PDF text extraction and page chunking with pdf-parse

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,8 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
-        "multer": "^2.0.2"
+        "multer": "^2.0.2",
+        "pdf-parse": "^1.1.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -20,6 +21,7 @@
         "@types/express": "^5.0.3",
         "@types/multer": "^2.0.0",
         "@types/node": "^24.1.0",
+        "@types/pdf-parse": "^1.1.5",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.8.3"
@@ -192,6 +194,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -1210,6 +1222,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1295,6 +1313,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/picomatch": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
@@ -23,6 +24,7 @@
     "@types/express": "^5.0.3",
     "@types/multer": "^2.0.0",
     "@types/node": "^24.1.0",
+    "@types/pdf-parse": "^1.1.5",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.8.3"

--- a/backend/src/controllers/pdfController.ts
+++ b/backend/src/controllers/pdfController.ts
@@ -1,23 +1,32 @@
 import { Request, Response, NextFunction } from 'express'
+import path from 'path'
+import { extractPdfTextByPage } from '../services/pdfTextService'
 
-export const uploadPdf = (req: Request, res: Response, next: NextFunction) => {
-  try {
-    if (!req.file) {
-      return res.status(400).json({ error: 'PDF file is required' })
+export const uploadPdf = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (!req.file) {
+            return res.status(400).json({ error: 'PDF file is required' })
+        }
+
+        const fileUrl = `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`
+        const filePath = path.join(process.cwd(), 'uploads', req.file.filename)
+
+        // Extract text from PDF by pages
+        const pages = await extractPdfTextByPage(filePath)
+
+        // For debugging, return extracted pages as well 
+        res.status(200).json({
+            message: 'File uploaded & text extracted successfully',
+            file: {
+                filename: req.file.filename,
+                originalname: req.file.originalname,
+                size: req.file.size,
+                url: fileUrl,
+                totalPages: pages.length,
+                extractedPages: pages
+            }
+        })
+    } catch (error) {
+        next(error)
     }
-
-    const fileUrl = `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`
-
-    res.status(200).json({
-      message: 'File uploaded successfully',
-      file: {
-        filename: req.file.filename,
-        originalname: req.file.originalname,
-        size: req.file.size,
-        url: fileUrl
-      }
-    })
-  } catch (error) {
-    next(error)
-  }
 }

--- a/backend/src/services/pdfTextService.ts
+++ b/backend/src/services/pdfTextService.ts
@@ -1,0 +1,12 @@
+import fs from 'fs'
+import pdfParse from 'pdf-parse'
+
+// Extracts text (by page) from a PDF file
+
+export async function extractPdfTextByPage(filePath: string): Promise<string[]> {
+    const dataBuffer = fs.readFileSync(filePath)
+    const pdfData = await pdfParse(dataBuffer)
+    // Optional: Split text by page using the form feed delimiter used by pdf-parse
+    const pages: string[] = pdfData.text.split('\f').map(s => s.trim()).filter(Boolean)
+    return pages
+}


### PR DESCRIPTION
# Feature: PDF Text Extraction & Chunking

- Integrates `pdf-parse` to extract text from uploaded PDFs, chunked by page.
- Service returns array of page texts for further vectorization/AI.
- Added to PDF upload controller for immediate post-upload processing.
- Prepares groundwork for semantic search and AI chat features.

## Testing

1. Upload a PDF via POST `/api/pdf/upload`
2. Response includes the number of pages and extracted page text array
3. Validate extraction quality and no crashes on various PDFs

## Next Steps

- Store extracted text in DB or prepare for embedding/vectorization.
- Hide sensitive data from final upload responses.
