### PR TITLE
feat(backend): store extracted PDF text pages in-memory for retrieval

### DIFF
--- a/backend/src/controllers/pdfController.ts
+++ b/backend/src/controllers/pdfController.ts
@@ -1,32 +1,51 @@
+// src/controllers/pdfController.ts
+
 import { Request, Response, NextFunction } from 'express'
 import path from 'path'
 import { extractPdfTextByPage } from '../services/pdfTextService'
+import { saveDocument } from '../services/inMemoryDocumentStore'
 
+/**
+ * Handles PDF upload request.
+ * - Validates presence of uploaded file.
+ * - Reads PDF from disk using absolute path.
+ * - Extracts text content by page.
+ * - Stores the extracted page texts in-memory keyed by filename.
+ * - Constructs public URL to the uploaded PDF.
+ * - Returns upload metadata and total page count (no raw text in response).
+ */
 export const uploadPdf = async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        if (!req.file) {
-            return res.status(400).json({ error: 'PDF file is required' })
-        }
-
-        const fileUrl = `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`
-        const filePath = path.join(process.cwd(), 'uploads', req.file.filename)
-
-        // Extract text from PDF by pages
-        const pages = await extractPdfTextByPage(filePath)
-
-        // For debugging, return extracted pages as well 
-        res.status(200).json({
-            message: 'File uploaded & text extracted successfully',
-            file: {
-                filename: req.file.filename,
-                originalname: req.file.originalname,
-                size: req.file.size,
-                url: fileUrl,
-                totalPages: pages.length,
-                extractedPages: pages
-            }
-        })
-    } catch (error) {
-        next(error)
+  try {
+    // Ensure a file was uploaded by multer
+    if (!req.file) {
+      return res.status(400).json({ error: 'PDF file is required' })
     }
+
+    // Construct absolute file path to uploaded PDF
+    const filePath = path.join(process.cwd(), 'uploads', req.file.filename)
+
+    // Extract array of texts, one per PDF page
+    const pages = await extractPdfTextByPage(filePath)
+
+    // Save extracted texts in an in-memory store for further processing (embedding, chat)
+    saveDocument(req.file.filename, req.file.originalname, pages)
+
+    // Construct public URL for frontend to access uploaded PDF
+    const fileUrl = `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`
+
+    // Respond with metadata and total pages count (do not expose extracted raw text)
+    return res.status(200).json({
+      message: 'File uploaded & text extracted successfully',
+      file: {
+        filename: req.file.filename,
+        originalname: req.file.originalname,
+        size: req.file.size,
+        url: fileUrl,
+        totalPages: pages.length, // Share total pages info
+      },
+    })
+  } catch (error) {
+    // Pass any errors to global error handling middleware
+    next(error)
+  }
 }

--- a/backend/src/services/inMemoryDocumentStore.ts
+++ b/backend/src/services/inMemoryDocumentStore.ts
@@ -1,0 +1,44 @@
+/**
+ * Service to maintain an in-memory store for uploaded documents and their extracted page text.
+ * This is a simple storage solution for development and prototyping.
+ * For production,we acn consider database or vector DB storage.
+ */
+
+export type PageText = {
+  pageNumber: number
+  text: string
+}
+
+export interface DocumentData {
+  fileName: string
+  pages: PageText[]
+}
+
+// Map keyed by docId (e.g. filename or UUID)
+const documentStore = new Map<string, DocumentData>()
+
+/**
+ * Save a document's extracted text pages by document ID.
+ * @param docId unique string key to identify doc (e.g., filename or generated UUID)
+ * @param fileName original file name
+ * @param pages array of text extracted from each page
+ */
+export function saveDocument(docId: string, fileName: string, pages: string[]): void {
+  const pageData: PageText[] = pages.map((text, index) => ({
+    pageNumber: index + 1,
+    text,
+  }))
+  documentStore.set(docId, {
+    fileName,
+    pages: pageData,
+  })
+}
+
+/**
+ * Retrieve document data by document ID.
+ * @param docId document's unique ID string
+ * @returns DocumentData | undefined if not found
+ */
+export function getDocument(docId: string): DocumentData | undefined {
+  return documentStore.get(docId)
+}


### PR DESCRIPTION
# Feature: In-memory storage for extracted PDF texts

- Saves extracted page-wise text from uploaded PDFs in memory store keyed by document ID
- Prepares foundation for vector embedding and retrieval
- Keeps upload API response clean, returning only metadata (e.g., total page count)
- Tested uploading multiple PDFs, storage works correctly

## Next Steps
- Implement vector embeddings generation and persistence
- Build chat endpoint using retrieved chunks
